### PR TITLE
Updated header nav to include link to PA user guide

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,33 @@
+<header class="site-header">
+
+    <div class="wrapper">
+      {%- assign default_paths = site.pages | map: "path" -%}
+      {%- assign page_paths = site.header_pages | default: default_paths -%}
+      {%- assign titles_size = site.pages | map: 'title' | join: '' | size -%}
+      <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+  
+      {%- if titles_size > 0 -%}
+        <nav class="site-nav">
+          <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+          <label for="nav-trigger">
+            <span class="menu-icon">
+              <svg viewBox="0 0 18 15" width="18px" height="15px">
+                <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+              </svg>
+            </span>
+          </label>
+  
+          <div class="trigger">
+            {%- for path in page_paths -%}
+              {%- assign my_page = site.pages | where: "path", path | first -%}              
+              {%- if my_page.title -%}
+              <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+              {%- elsif my_page.url_override and my_page.header_title -%}
+              <a class="page-link" href="{{ my_page.url_override }}">{{ my_page.header_title | escape }}</a>              
+              {%- endif -%}
+            {%- endfor -%}
+          </div>
+        </nav>
+      {%- endif -%}
+    </div>
+  </header>

--- a/blog.md
+++ b/blog.md
@@ -1,0 +1,14 @@
+---
+# Feel free to add content and custom Front Matter to this file.
+# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+
+order: 1
+---
+
+# Blog
+
+## Available Pages:
+
+{% for post in site.posts %}
+-   [{{ post.title }}]({{ post.url }})
+{% endfor %}

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,7 +1,0 @@
-# Blog
-
-## Available Pages:
-
-{% for post in site.posts %}
--   [{{ post.title }}]({{ post.url }})
-{% endfor %}

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
         <ul class="navbar-nav ml-auto">
           <li class="nav-item"><a href="/" class="nav-link">Home</a></li>
           <li class="nav-item"><a href="/blog" class="nav-link">Blog</a></li>
+          <li class="nav-item"><a href="https://pa.tython.co" class="nav-link">Permissions Assistant</a></li>
           <!--<li class="nav-item"><a href="clients.html" class="nav-link">Services</a></li>
           <li class="nav-item"><a href="contact.html" class="nav-link">Contact</a></li>-->
         </ul>

--- a/pa.md
+++ b/pa.md
@@ -1,0 +1,8 @@
+---
+# Feel free to add content and custom Front Matter to this file.
+# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+
+header_title: Permissions Assistant
+order: 2
+url_override: https://pa.tython.co/
+---


### PR DESCRIPTION
`To Test`
- [x] Run `npm test`
- [x] Confirm that the header nav bar is updated to include a link to the PA subdomain (pa.tython.co)
- [x] Confirm this new link is accessible from the homepage and from [the blog page](tython.co/blog)